### PR TITLE
Set standard to c++17 for g++ for inline static constexpr to work. Fixes issue #3

### DIFF
--- a/cmake/ViennaLSConfig.cmake.in
+++ b/cmake/ViennaLSConfig.cmake.in
@@ -8,6 +8,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -fopenmp=libomp")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 #    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Werror -fmax-errors=2")
+    # g++ needs c++17 standard for inline static constexpr variables
+    SET(CMAKE_CXX_STANDARD "17")
     FIND_PACKAGE(OpenMP REQUIRED)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall ${OpenMP_CXX_FLAGS}")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")


### PR DESCRIPTION
Clang still works on C++11