### PR TITLE
Fixed issue #21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if(VIENNALS_USE_VTK)
     add_definitions(-DVIENNALS_USE_VTK)
     include(${VTK_USE_FILE})
     # only link needed vtk libraries
-    set(VTK_LIBRARIES vtksys;vtkIOCore;vtkexpat;vtklz4;vtkzlib;vtklzma;vtkdoubleconversion;vtkCommonMisc;vtkCommonSystem;vtkIOXML)
+    #set(VTK_LIBRARIES vtksys;vtkIOCore;vtkexpat;vtklz4;vtkzlib;vtklzma;vtkdoubleconversion;vtkCommonMisc;vtkCommonSystem;vtkIOXML)
     list(APPEND VIENNALS_LIBRARIES ${VTK_LIBRARIES})
     list(APPEND VIENNALS_PYTHON_LIBRARIES ${VTK_LIBRARIES})
   else(VTK_FOUND)

--- a/include/lsFiniteDifferences.hpp
+++ b/include/lsFiniteDifferences.hpp
@@ -32,6 +32,9 @@ public:
       return 5;
     case DifferentiationSchemeEnum::WENO5:
       return 7;
+    default:
+      lsMessage::getInstance().addError("Invalid finite differences scheme!");
+      return 0;
     }
   }
 


### PR DESCRIPTION
* Removed CMake line which limited the number of VTK libraries linked
* Added default case to lsFiniteDifferences getNumberOfValues to remove g++ warning message.