### PR TITLE
Fixed auto detection for file ending in lsVTKReader/Writer

### DIFF
--- a/include/lsVTKReader.hpp
+++ b/include/lsVTKReader.hpp
@@ -68,7 +68,15 @@ public:
     }
 
     if (fileFormat == lsFileFormatEnum::VTK_AUTO) {
-      auto ending = fileName.substr(fileName.find_last_of('.'));
+      auto dotPos = fileName.rfind('.');
+      if (dotPos == std::string::npos) {
+        lsMessage::getInstance()
+            .addWarning("No valid file format found based on the file ending "
+                        "passed to lsVTKReader. Not reading.")
+            .print();
+        return;
+      }
+      auto ending = fileName.substr(dotPos);
       if (ending == ".vtk") {
         fileFormat = lsFileFormatEnum::VTK_LEGACY;
       } else if (ending == ".vtp") {

--- a/include/lsVTKWriter.hpp
+++ b/include/lsVTKWriter.hpp
@@ -99,19 +99,24 @@ public:
     }
 
     if (fileFormat == lsFileFormatEnum::VTK_AUTO) {
-      auto ending = fileName.substr(fileName.find_last_of('.'));
-      if (ending == ".vtk") {
-        fileFormat = lsFileFormatEnum::VTK_LEGACY;
-      } else if (ending == ".vtp") {
+      auto dotPos = fileName.rfind('.');
+      if (dotPos == std::string::npos) {
         fileFormat = lsFileFormatEnum::VTP;
-      } else if (ending == ".vtu") {
-        fileFormat = lsFileFormatEnum::VTU;
       } else {
-        lsMessage::getInstance()
-            .addWarning("No valid file format found based on the file ending "
-                        "passed to lsVTKWriter. Not writing.")
-            .print();
-        return;
+        auto ending = fileName.substr();
+        if (ending == ".vtk") {
+          fileFormat = lsFileFormatEnum::VTK_LEGACY;
+        } else if (ending == ".vtp") {
+          fileFormat = lsFileFormatEnum::VTP;
+        } else if (ending == ".vtu") {
+          fileFormat = lsFileFormatEnum::VTU;
+        } else {
+          lsMessage::getInstance()
+              .addWarning("No valid file format found based on the file ending "
+                          "passed to lsVTKWriter. Not writing.")
+              .print();
+          return;
+        }
       }
     }
 


### PR DESCRIPTION
- When a file name without a file ending was passed, the auto detection failed.
- lsVTKReader: do not read if there is no valid file ending
- lsVTKWriter: use VTP format