### PR TITLE
Fixes for lsToVoxelMesh

### DIFF
--- a/include/lsSmartPointer.hpp
+++ b/include/lsSmartPointer.hpp
@@ -14,11 +14,11 @@ public:
   // Make visible all constructors of std::shared_ptr
   // including copy constructors
   template <typename... Args>
-  lsSmartPointer(Args &&... args)
+  lsSmartPointer(Args &&...args)
       : std::shared_ptr<T>(std::forward<Args>(args)...) {}
 
   /// Use this function to create new objects when using ViennaLS
-  template <typename... TArgs> static lsSmartPointer New(TArgs &&... targs) {
+  template <typename... TArgs> static lsSmartPointer New(TArgs &&...targs) {
     return lsSmartPointer(std::make_shared<T>(std::forward<TArgs>(targs)...));
   }
 };

--- a/include/lsToVoxelMesh.hpp
+++ b/include/lsToVoxelMesh.hpp
@@ -152,11 +152,9 @@ public:
             mesh->hexas.push_back(hexa);
             materialIds.push_back(materialId);
           } else {
-            std::array<unsigned, 3> triangle{voxel[0], voxel[1], voxel[2]};
-            mesh->triangles.push_back(triangle);
-            materialIds.push_back(materialId);
-            triangle[0] = voxel[3];
-            mesh->triangles.push_back(triangle);
+            std::array<unsigned, 4> tetra{voxel[0], voxel[2], voxel[3],
+                                          voxel[1]};
+            mesh->tetras.push_back(tetra);
             materialIds.push_back(materialId);
           }
           // jump out of material for loop

--- a/include/lsToVoxelMesh.hpp
+++ b/include/lsToVoxelMesh.hpp
@@ -110,14 +110,15 @@ public:
 
     // move iterator for lowest material id and then adjust others if they are
     // needed
-    for (; iterators.back().getIndices() < maxIndex; iterators.back().next()) {
+    for (; iterators.front().getIndices() < maxIndex;
+         iterators.front().next()) {
       // go over all materials
       for (unsigned materialId = 0; materialId < levelSets.size();
            ++materialId) {
 
         auto &cellIt = iterators[materialId];
 
-        cellIt.goToIndicesSequential(iterators.back().getIndices());
+        cellIt.goToIndicesSequential(iterators.front().getIndices());
 
         // find out whether the centre of the box is inside
         T centerValue = 0.;
@@ -130,16 +131,22 @@ public:
           // now insert all points of voxel into pointList
           for (unsigned i = 0; i < (1 << D); ++i) {
             hrleVectorType<hrleIndexType, D> index;
+            bool add = true;
             for (unsigned j = 0; j < D; ++j) {
               index[j] =
                   cellIt.getIndices(j) + cellIt.getCorner(i).getOffset()[j];
+              if (index[j] > maxIndex[j]) {
+                add = false;
+                break;
+              }
             }
-            auto pointIdValue = std::make_pair(index, currentPointId);
-
-            auto pointIdPair = pointIdMapping.insert(pointIdValue);
-            voxel[i] = pointIdPair.first->second;
-            if (pointIdPair.second) {
-              ++currentPointId;
+            if (add) {
+              auto pointIdValue = std::make_pair(index, currentPointId);
+              auto pointIdPair = pointIdMapping.insert(pointIdValue);
+              voxel[i] = pointIdPair.first->second;
+              if (pointIdPair.second) {
+                ++currentPointId;
+              }
             }
           }
 

--- a/include/lsWriteVisualizationMesh.hpp
+++ b/include/lsWriteVisualizationMesh.hpp
@@ -23,9 +23,9 @@
 
 #include <hrleDenseIterator.hpp>
 
-#include <lsPreCompileMacros.hpp>
 #include <lsDomain.hpp>
 #include <lsMessage.hpp>
+#include <lsPreCompileMacros.hpp>
 
 //#define LS_TO_VISUALIZATION_DEBUG
 #ifdef LS_TO_VISUALIZATION_DEBUG


### PR DESCRIPTION
- Changed the iterator order in the voxel creation loop.
- Added additional condition to only add voxels, if they are inside the initial level set boundaries.
- Changed 2D voxels from 2 triangles to 1 tetra. This makes it easier to work with them in a cell grid and also seems more intuitive than 2 triangles.

The changes fix issue #85 .