### PR TITLE
Extrude 2D level sets in 3D domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ _generate/
 *.egg-info
 *env*
 .mypy_cache/
+.eggs/

--- a/Python/pyWrap.cpp
+++ b/Python/pyWrap.cpp
@@ -27,6 +27,7 @@
 #include <lsDetectFeatures.hpp>
 #include <lsDomain.hpp>
 #include <lsExpand.hpp>
+#include <lsExtrude.hpp>
 #include <lsFileFormats.hpp>
 #include <lsFromMesh.hpp>
 #include <lsFromSurfaceMesh.hpp>
@@ -508,6 +509,26 @@ PYBIND11_MODULE(VIENNALS_MODULE_NAME, module) {
            "Set levelset to expand.")
       .def("setWidth", &lsExpand<T, D>::setWidth, "Set the width to expand to.")
       .def("apply", &lsExpand<T, D>::apply, "Perform expansion.");
+
+  // lsExtrude
+  pybind11::class_<lsExtrude<T>, lsSmartPointer<lsExtrude<T>>>(module,
+                                                               "lsExtrude")
+      // constructors
+      .def(pybind11::init(&lsSmartPointer<lsExtrude<T>>::New<>))
+      .def(pybind11::init(
+          &lsSmartPointer<lsExtrude<T>>::New<lsSmartPointer<lsDomain<T, 2>> &,
+                                             lsSmartPointer<lsDomain<T, 3>> &,
+                                             std::array<T, 2>, const int>))
+      // methods
+      .def("setInputLevelSet", &lsExtrude<T>::setInputLevelSet,
+           "Set 2D input Level Set")
+      .def("setOutputLevelSet", &lsExtrude<T>::setOutputLevelSet,
+           "Set 3D output Level Set")
+      .def("setExtent", &lsExtrude<T>::setExtent,
+           "Set the extent in the extruded dimension")
+      .def("setExtrudeDimension", &lsExtrude<T>::setExtrudeDimension,
+           "Set the dimension which should be extruded")
+      .def("apply", &lsExtrude<T>::apply, "Perform extrusion.");
 
   // lsFileFormats
   pybind11::enum_<lsFileFormatEnum>(module, "lsFileFormatEnum")

--- a/Python/pyWrap.cpp
+++ b/Python/pyWrap.cpp
@@ -511,24 +511,37 @@ PYBIND11_MODULE(VIENNALS_MODULE_NAME, module) {
       .def("apply", &lsExpand<T, D>::apply, "Perform expansion.");
 
   // lsExtrude
-  pybind11::class_<lsExtrude<T>, lsSmartPointer<lsExtrude<T>>>(module,
-                                                               "lsExtrude")
-      // constructors
-      .def(pybind11::init(&lsSmartPointer<lsExtrude<T>>::New<>))
-      .def(pybind11::init(
-          &lsSmartPointer<lsExtrude<T>>::New<lsSmartPointer<lsDomain<T, 2>> &,
-                                             lsSmartPointer<lsDomain<T, 3>> &,
-                                             std::array<T, 2>, const int>))
-      // methods
-      .def("setInputLevelSet", &lsExtrude<T>::setInputLevelSet,
-           "Set 2D input Level Set")
-      .def("setOutputLevelSet", &lsExtrude<T>::setOutputLevelSet,
-           "Set 3D output Level Set")
-      .def("setExtent", &lsExtrude<T>::setExtent,
-           "Set the extent in the extruded dimension")
-      .def("setExtrudeDimension", &lsExtrude<T>::setExtrudeDimension,
-           "Set the dimension which should be extruded")
-      .def("apply", &lsExtrude<T>::apply, "Perform extrusion.");
+  // Does not work in current implementation, because one can not import both 2D
+  // and 3D ViennaLS libraries in Python in the same file
+  //   pybind11::class_<lsExtrude<T>, lsSmartPointer<lsExtrude<T>>>(module,
+  //                                                                "lsExtrude")
+  //       // constructors
+  //       .def(pybind11::init(&lsSmartPointer<lsExtrude<T>>::New<>))
+  //       .def(
+  //           pybind11::init(&lsSmartPointer<lsExtrude<T>>::New<
+  //                          lsSmartPointer<lsDomain<T, 2>> &,
+  //                          lsSmartPointer<lsDomain<T, 3>> &, std::array<T,
+  //                          2>, const int,
+  //                          std::array<lsBoundaryConditionEnum<3>, 3>>))
+  //       // methods
+  //       .def("setInputLevelSet", &lsExtrude<T>::setInputLevelSet,
+  //            "Set 2D input Level Set")
+  //       .def("setOutputLevelSet", &lsExtrude<T>::setOutputLevelSet,
+  //            "Set 3D output Level Set")
+  //       .def("setExtent", &lsExtrude<T>::setExtent,
+  //            "Set the extent in the extruded dimension")
+  //       .def("setExtrudeDimension", &lsExtrude<T>::setExtrudeDimension,
+  //            "Set the dimension which should be extruded")
+  //       .def("setBoundaryConditions",
+  //            pybind11::overload_cast<std::array<lsBoundaryConditionEnum<3>,
+  //            3>>(
+  //                &lsExtrude<T>::setBoundaryConditions),
+  //            "Set the boundary conditions in the 3D extruded domain.")
+  //       .def("setBoundaryConditions",
+  //            pybind11::overload_cast<lsBoundaryConditionEnum<3> *>(
+  //                &lsExtrude<T>::setBoundaryConditions),
+  //            "Set the boundary conditions in the 3D extruded domain.")
+  //       .def("apply", &lsExtrude<T>::apply, "Perform extrusion.");
 
   // lsFileFormats
   pybind11::enum_<lsFileFormatEnum>(module, "lsFileFormatEnum")

--- a/Tests/Extrude/CMakeLists.txt
+++ b/Tests/Extrude/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.14)
+
+project("Extrude")
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC ${VIENNALS_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${VIENNALS_LIBRARIES})
+
+add_dependencies(buildTests ${PROJECT_NAME})
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>)

--- a/Tests/Extrude/Extrude.cpp
+++ b/Tests/Extrude/Extrude.cpp
@@ -61,7 +61,7 @@ int main() {
 
   std::array<double, 2> extrudeExtent = {-5., 5.};
   auto trench_3D = lsSmartPointer<lsDomain<double, 3>>::New();
-  lsExtrude<double>(trench, trench_3D, extrudeExtent, 1).apply();
+  lsExtrude<double>(trench, trench_3D, extrudeExtent, 2).apply();
 
   {
     auto mesh = lsSmartPointer<lsMesh<>>::New();

--- a/Tests/Extrude/Extrude.cpp
+++ b/Tests/Extrude/Extrude.cpp
@@ -60,8 +60,12 @@ int main() {
   }
 
   std::array<double, 2> extrudeExtent = {-5., 5.};
+  std::array<lsBoundaryConditionEnum<3>, 3> boundaryConds{
+      lsBoundaryConditionEnum<3>::REFLECTIVE_BOUNDARY,
+      lsBoundaryConditionEnum<3>::INFINITE_BOUNDARY,
+      lsBoundaryConditionEnum<3>::REFLECTIVE_BOUNDARY};
   auto trench_3D = lsSmartPointer<lsDomain<double, 3>>::New();
-  lsExtrude<double>(trench, trench_3D, extrudeExtent, 2).apply();
+  lsExtrude<double>(trench, trench_3D, extrudeExtent, 2, boundaryConds).apply();
 
   {
     auto mesh = lsSmartPointer<lsMesh<>>::New();

--- a/Tests/Extrude/Extrude.cpp
+++ b/Tests/Extrude/Extrude.cpp
@@ -1,0 +1,73 @@
+#include <iostream>
+
+#include <lsBooleanOperation.hpp>
+#include <lsDomain.hpp>
+#include <lsExtrude.hpp>
+#include <lsMakeGeometry.hpp>
+#include <lsMesh.hpp>
+#include <lsToMesh.hpp>
+#include <lsVTKWriter.hpp>
+
+/**
+  Simple example showing how to use lsExtrude in order
+  to transform a 2D trench into a 3D level set.
+  \example Extrude.cpp
+*/
+
+int main() {
+
+  omp_set_num_threads(4);
+
+  double extent = 15;
+  double gridDelta = 0.5;
+
+  // 2D domain boundaries
+  double bounds[2 * 2] = {-extent, extent, -extent, extent};
+  lsDomain<double, 2>::BoundaryType boundaryCons[2];
+  boundaryCons[0] = lsDomain<double, 2>::BoundaryType::REFLECTIVE_BOUNDARY;
+  boundaryCons[1] = lsDomain<double, 2>::BoundaryType::INFINITE_BOUNDARY;
+
+  auto trench =
+      lsSmartPointer<lsDomain<double, 2>>::New(bounds, boundaryCons, gridDelta);
+
+  {
+    double origin[2] = {0., 0.};
+    double normal[2] = {0., 1.};
+
+    lsMakeGeometry<double, 2>(
+        trench, lsSmartPointer<lsPlane<double, 2>>::New(origin, normal))
+        .apply();
+
+    auto cutOut = lsSmartPointer<lsDomain<double, 2>>::New(bounds, boundaryCons,
+                                                           gridDelta);
+
+    double minPoint[2] = {-5., -5.};
+    double maxPoint[2] = {5., gridDelta};
+
+    lsMakeGeometry<double, 2>(
+        cutOut, lsSmartPointer<lsBox<double, 2>>::New(minPoint, maxPoint))
+        .apply();
+
+    lsBooleanOperation<double, 2>(trench, cutOut,
+                                  lsBooleanOperationEnum::RELATIVE_COMPLEMENT)
+        .apply();
+  }
+
+  {
+    auto mesh = lsSmartPointer<lsMesh<>>::New();
+    lsToMesh<double, 2>(trench, mesh).apply();
+    lsVTKWriter<double>(mesh, "trench_initial.vtp").apply();
+  }
+
+  std::array<double, 2> extrudeExtent = {-5., 5.};
+  auto trench_3D = lsSmartPointer<lsDomain<double, 3>>::New();
+  lsExtrude<double>(trench, trench_3D, extrudeExtent, 1).apply();
+
+  {
+    auto mesh = lsSmartPointer<lsMesh<>>::New();
+    lsToMesh<double, 3>(trench_3D, mesh).apply();
+    lsVTKWriter<double>(mesh, "trench_extrude.vtp").apply();
+  }
+
+  return 0;
+}

--- a/include/lsExtrude.hpp
+++ b/include/lsExtrude.hpp
@@ -5,7 +5,9 @@
 #include <lsFromSurfaceMesh.hpp>
 #include <lsToSurfaceMesh.hpp>
 
-// Extrude a 2D Level Set into a 3D domain.
+/// Extrudes a 2D Level Set into a 3D domain. The axis in which should be
+/// extruded can be set and boundary conditions in the 3D domain must be
+/// specified.
 template <class T> class lsExtrude {
   lsSmartPointer<lsDomain<T, 2>> inputLevelSet = nullptr;
   lsSmartPointer<lsDomain<T, 3>> outputLevelSet = nullptr;

--- a/include/lsExtrude.hpp
+++ b/include/lsExtrude.hpp
@@ -13,14 +13,14 @@
 // Extrude a 2D level-set into a 3D domain
 template <class T> class lsExtrude {
   lsSmartPointer<lsDomain<T, 2>> inputLevelSet = nullptr;
-  lsSmartPointer<lsDomain<T, 3>> &outputLevelSet = nullptr;
+  lsSmartPointer<lsDomain<T, 3>> outputLevelSet = nullptr;
   std::array<T, 2> extent = {0., 0.};
   int extrudeDim = 0;
 
 public:
   lsExtrude() {}
   lsExtrude(lsSmartPointer<lsDomain<T, 2>> passedInputLS,
-            lsSmartPointer<lsDomain<T, 3>> &passedOutputLS,
+            lsSmartPointer<lsDomain<T, 3>> passedOutputLS,
             std::array<T, 2> passedExtent, const int passedExtrudeDim = 0)
       : inputLevelSet(passedInputLS), outputLevelSet(passedOutputLS),
         extent(passedExtent), extrudeDim(passedExtrudeDim) {}
@@ -79,8 +79,9 @@ public:
       boundaryConds[extrudeDims[1]] =
           convertBoundaryCondition(inputBoundaryConds[extrudeDims[1]]);
 
-      outputLevelSet = lsSmartPointer<lsDomain<T, 3>>::New(
+      auto tmpLevelSet = lsSmartPointer<lsDomain<T, 3>>::New(
           domainBounds, boundaryConds, gridDelta);
+      outputLevelSet->deepCopy(tmpLevelSet);
     }
 
     auto surface = lsSmartPointer<lsMesh<T>>::New();

--- a/include/lsExtrude.hpp
+++ b/include/lsExtrude.hpp
@@ -1,0 +1,149 @@
+#ifndef LS_EXTRUDE_HPP
+#define LS_EXTRUDE_HPP
+
+#include <unordered_set>
+
+#include <lsDomain.hpp>
+#include <lsFromSurfaceMesh.hpp>
+#include <lsMakeGeometry.hpp>
+#include <lsToMesh.hpp>
+#include <lsToSurfaceMesh.hpp>
+#include <lsVTKWriter.hpp>
+
+// Extrude a 2D level-set into a 3D domain
+template <class T> class lsExtrude {
+  lsSmartPointer<lsDomain<T, 2>> inputLevelSet = nullptr;
+  lsSmartPointer<lsDomain<T, 3>> &outputLevelSet = nullptr;
+  std::array<T, 2> extent = {0., 0.};
+  int extrudeDim = 0;
+
+public:
+  lsExtrude() {}
+  lsExtrude(lsSmartPointer<lsDomain<T, 2>> passedInputLS,
+            lsSmartPointer<lsDomain<T, 3>> &passedOutputLS,
+            std::array<T, 2> passedExtent, const int passedExtrudeDim = 0)
+      : inputLevelSet(passedInputLS), outputLevelSet(passedOutputLS),
+        extent(passedExtent), extrudeDim(passedExtrudeDim) {}
+
+  void setInputLevelSet(lsSmartPointer<lsDomain<T, 2>> passedInputLS) {
+    inputLevelSet = passedInputLS;
+  }
+
+  void setOutputLevelSet(lsSmartPointer<lsDomain<T, 3>> &passedOutputLS) {
+    outputLevelSet = passedOutputLS;
+  }
+
+  void setExtent(std::array<T, 2> passedExtent) { extent = passedExtent; }
+
+  void setExtrudeDimension(const int passedExtrudeDim) {
+    extrudeDim = passedExtrudeDim;
+  }
+
+  void apply() {
+    if (inputLevelSet == nullptr) {
+      lsMessage::getInstance()
+          .addWarning(
+              "No input Level Set supplied to lsExtrude! Not converting.")
+          .print();
+    }
+    if (outputLevelSet == nullptr) {
+      lsMessage::getInstance()
+          .addWarning(
+              "No output Level Set supplied to lsExtrude! Not converting.")
+          .print();
+      return;
+    }
+
+    const T gridDelta = inputLevelSet->getGrid().getGridDelta();
+    const auto extrudeDims = getExtrudeDims();
+
+    {
+      const auto inputBoundaryConds =
+          inputLevelSet->getGrid().getBoundaryConditions();
+      auto minBounds = inputLevelSet->getGrid().getMinBounds();
+      auto maxBounds = inputLevelSet->getGrid().getMaxBounds();
+
+      double domainBounds[2 * 3];
+      domainBounds[2 * extrudeDim] = extent[0];
+      domainBounds[2 * extrudeDim + 1] = extent[1];
+      domainBounds[2 * extrudeDims[0]] = gridDelta * minBounds[0];
+      domainBounds[2 * extrudeDims[0] + 1] = gridDelta * maxBounds[0];
+      domainBounds[2 * extrudeDims[1]] = gridDelta * minBounds[1];
+      domainBounds[2 * extrudeDims[1] + 1] = gridDelta * maxBounds[1];
+
+      lsBoundaryConditionEnum<3> boundaryConds[3];
+      boundaryConds[extrudeDim] =
+          convertBoundaryCondition(inputBoundaryConds[extrudeDims[0]]);
+      boundaryConds[extrudeDims[0]] =
+          convertBoundaryCondition(inputBoundaryConds[extrudeDims[0]]);
+      boundaryConds[extrudeDims[1]] =
+          convertBoundaryCondition(inputBoundaryConds[extrudeDims[1]]);
+
+      outputLevelSet = lsSmartPointer<lsDomain<T, 3>>::New(
+          domainBounds, boundaryConds, gridDelta);
+    }
+
+    auto surface = lsSmartPointer<lsMesh<T>>::New();
+    lsToSurfaceMesh<T, 2>(inputLevelSet, surface).apply();
+
+    auto &lines = surface->template getElements<2>();
+    auto &nodes = surface->getNodes();
+    const unsigned numNodes = nodes.size();
+
+    for (unsigned i = 0; i < numNodes; i++) {
+      nodes[i][extrudeDims[1]] = nodes[i][1];
+      nodes[i][extrudeDims[0]] = nodes[i][0];
+      nodes[i][extrudeDim] = extent[1];
+
+      nodes.push_back(nodes[i]);
+
+      nodes[i][extrudeDim] = extent[0];
+    }
+
+    for (unsigned i = 0; i < lines.size(); i++) {
+      std::array<unsigned, 3> triangle = {lines[i][0], lines[i][1],
+                                          lines[i][0] + numNodes};
+      surface->insertNextTriangle(triangle);
+
+      triangle[0] = lines[i][1];
+      triangle[1] = lines[i][1] + numNodes;
+      triangle[2] = lines[i][0] + numNodes;
+      surface->insertNextTriangle(triangle);
+    }
+
+    surface->template getElements<2>().clear();
+    lsFromSurfaceMesh<T, 3>(outputLevelSet, surface).apply();
+  }
+
+private:
+  lsBoundaryConditionEnum<3>
+  convertBoundaryCondition(lsBoundaryConditionEnum<2> boundaryCond) {
+    switch (boundaryCond) {
+    case lsBoundaryConditionEnum<2>::PERIODIC_BOUNDARY:
+      return lsBoundaryConditionEnum<3>::PERIODIC_BOUNDARY;
+    case lsBoundaryConditionEnum<2>::INFINITE_BOUNDARY:
+      return lsBoundaryConditionEnum<3>::INFINITE_BOUNDARY;
+    case lsBoundaryConditionEnum<2>::POS_INFINITE_BOUNDARY:
+      return lsBoundaryConditionEnum<3>::POS_INFINITE_BOUNDARY;
+    case lsBoundaryConditionEnum<2>::NEG_INFINITE_BOUNDARY:
+      return lsBoundaryConditionEnum<3>::NEG_INFINITE_BOUNDARY;
+    case lsBoundaryConditionEnum<2>::REFLECTIVE_BOUNDARY:
+      return lsBoundaryConditionEnum<3>::REFLECTIVE_BOUNDARY;
+    default:
+      return lsBoundaryConditionEnum<3>::INFINITE_BOUNDARY;
+    }
+  }
+
+  std::array<unsigned, 2> getExtrudeDims() {
+    assert(extrudeDim < 3);
+    if (extrudeDim == 0) {
+      return {1, 2};
+    } else if (extrudeDim == 1) {
+      return {0, 2};
+    } else {
+      return {0, 1};
+    }
+  }
+};
+
+#endif // LS_EXTRUDE_HPP


### PR DESCRIPTION
Added a tool to extrude 2D geometries into 3D.

To tool currently does not work in Python because both 2D and 3D versions or ViennaLS are need.